### PR TITLE
add grpc client Dialer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: go
 go:
-  - 1.7
   - 1.8
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ go:
 install:
   - go get -t ./...
 
-
-
 script:
- - go test -race -v ./...
+ - ./test_all.sh
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/grpc/backendpool/backend.go
+++ b/grpc/backendpool/backend.go
@@ -56,7 +56,12 @@ func (b *backend) Conn() (*grpc.ClientConn, error) {
 }
 
 func (b *backend) Close() error {
-	return b.conn.Close()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.conn != nil {
+		return b.conn.Close()
+	}
+	return nil
 }
 
 func newBackend(cnf *pb.Backend) (*backend, error) {

--- a/grpc/client/client.go
+++ b/grpc/client/client.go
@@ -1,0 +1,48 @@
+package kedge_grpc
+
+import (
+	"crypto/tls"
+	"errors"
+
+	"github.com/mwitkow/kedge/lib/map"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// DialThroughKedge provides a grpc.ClientConn that forwards all traffic to the specific kedge.
+//
+// For secure kedging (with a mapper value starting with https://) clientTls option needs to be set, and needs to point
+// to a tls.Config that has client side certificates configured.
+func DialThroughKedge(ctx context.Context, targetAuthority string, clientTls *tls.Config, mapper kedge_map.Mapper, grpcOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	kedgeUrl, err := mapper.Map(targetAuthority)
+	if err != nil {
+		return nil, err
+	}
+	if kedgeUrl.Scheme == "https" {
+		if clientTls == nil || (len(clientTls.Certificates) == 0 && clientTls.GetCertificate == nil) {
+			return nil, errors.New("dialing through kedge requires a tls.Config with client-side certificates")
+		}
+		transportCreds := credentials.NewTLS(clientTls)
+		transportCreds = &proxiedTlsCredentials{TransportCredentials: transportCreds, authorityNameOverride: targetAuthority}
+		grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(transportCreds))
+	} else {
+		grpcOpts = append(grpcOpts, grpc.WithInsecure(), grpc.WithAuthority(targetAuthority))
+	}
+	// TODO(mwitkow): Add pooled dialing a-la: https://sourcegraph.com/github.com/google/google-api-go-client@master/-/blob/internal/pool.go#L25:1-27:32
+	return grpc.DialContext(ctx, kedgeUrl.Host, grpcOpts...)
+}
+
+type proxiedTlsCredentials struct {
+	credentials.TransportCredentials
+	authorityNameOverride string
+}
+
+func (c *proxiedTlsCredentials) Info() credentials.ProtocolInfo {
+	info := c.TransportCredentials.Info()
+	// gRPC Clients set authority per DialContext rules. For TLS, authority comes from ProtocolInfo.
+	// This value is not overrideable inside the metadata, since two `:authority` headers would be written, causing an
+	// error on the transport.
+	info.ServerName = c.authorityNameOverride
+	return info
+}

--- a/grpc/integration_test.go
+++ b/grpc/integration_test.go
@@ -272,7 +272,7 @@ func (s *BackendPoolIntegrationTestSuite) TestClientDialSecureToNonSecureBackend
 
 func (s *BackendPoolIntegrationTestSuite) invokeUnknownHandlerPingbackAndAssert(fullMethod string, conn *grpc.ClientConn) *unknownResponse {
 	resp := &unknownResponse{}
-	err := grpc.Invoke(s.SimpleCtx(), fullMethod, &unknownResponse{}, resp, s.proxyConn)
+	err := grpc.Invoke(s.SimpleCtx(), fullMethod, &unknownResponse{}, resp, conn)
 	require.NoError(s.T(), err, "no error on call to unknown handler call")
 	assert.Equal(s.T(), fullMethod, resp.Method)
 	return resp

--- a/grpc/integration_test.go
+++ b/grpc/integration_test.go
@@ -241,7 +241,7 @@ func (s *BackendPoolIntegrationTestSuite) buildBackends() {
 }
 
 func (s *BackendPoolIntegrationTestSuite) SimpleCtx() context.Context {
-	ctx, _ := context.WithTimeout(context.TODO(), 2*time.Second)
+	ctx, _ := context.WithTimeout(context.TODO(), 5*time.Second)
 	return ctx
 }
 

--- a/grpc/integration_test.go
+++ b/grpc/integration_test.go
@@ -263,7 +263,7 @@ func (s *BackendPoolIntegrationTestSuite) TestCallToSecureBackend() {
 
 func (s *BackendPoolIntegrationTestSuite) TestClientDialSecureToNonSecureBackend() {
 	// This tests whether the DialThroughKedge passes the authority correctly
-	cc, err := kedge_grpc.DialThroughKedge(s.SimpleCtx(), "secure.ext.test.local", s.tlsConfigForTest(), s.kedgeMapper)
+	cc, err := kedge_grpc.DialThroughKedge(context.TODO(), "secure.ext.test.local", s.tlsConfigForTest(), s.kedgeMapper)
 	require.NoError(s.T(), err, "dialing through kedge must succeed")
 	defer cc.Close()
 	resp := s.invokeUnknownHandlerPingbackAndAssert("/hand_rolled.common.NonSpecificService/Method", cc)

--- a/http/backendpool/pool.go
+++ b/http/backendpool/pool.go
@@ -3,10 +3,11 @@ package backendpool
 import (
 	"fmt"
 
+	"net/http"
+
 	pb "github.com/mwitkow/kedge/_protogen/kedge/config/http/backends"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"net/http"
 )
 
 var (

--- a/http/director/router/adhoc_test.go
+++ b/http/director/router/adhoc_test.go
@@ -83,9 +83,9 @@ func TestAdhocMatches(t *testing.T) {
 			expectedAddr: "1.2.3.4:11200",
 		},
 		{
-			name:         "fails port check outside the boundary",
-			hostPort:     "1-2-3-4.namespace.pods.cluster.local:11201",
-			expectedErr:  "port 11201 is not allowed",
+			name:        "fails port check outside the boundary",
+			hostPort:    "1-2-3-4.namespace.pods.cluster.local:11201",
+			expectedErr: "port 11201 is not allowed",
 		},
 		{
 			name:         "matches non default allowed in list",
@@ -93,14 +93,14 @@ func TestAdhocMatches(t *testing.T) {
 			expectedAddr: "2.3.4.5:8081",
 		},
 		{
-			name:         "fails unmatched, even though addresses resolve",
-			hostPort:     "weird.cluster.local:8081",
-			expectedErr:  "unknown route to service",
+			name:        "fails unmatched, even though addresses resolve",
+			hostPort:    "weird.cluster.local:8081",
+			expectedErr: "unknown route to service",
 		},
 		{
-			name:         "fails dial errors",
-			hostPort:     "otherbackend.somenamespace.svc.cluster.local:8081",
-			expectedErr:  "cannot resolve host",
+			name:        "fails dial errors",
+			hostPort:    "otherbackend.somenamespace.svc.cluster.local:8081",
+			expectedErr: "cannot resolve host",
 		},
 	} {
 		t.Run(tcase.name, func(t *testing.T) {

--- a/http/director/router/error.go
+++ b/http/director/router/error.go
@@ -1,8 +1,7 @@
 package router
 
-
 type Error struct {
-	msg string
+	msg    string
 	status int
 }
 

--- a/http/director/router/router.go
+++ b/http/director/router/router.go
@@ -1,11 +1,10 @@
 package router
 
 import (
-
-	"strings"
+	"errors"
 	"net/http"
 	"net/url"
-	"errors"
+	"strings"
 
 	"github.com/mwitkow/kedge/http/director/proxyreq"
 	"google.golang.org/grpc/metadata"
@@ -14,7 +13,7 @@ import (
 )
 
 var (
-	emptyMd       = metadata.Pairs()
+	emptyMd          = metadata.Pairs()
 	ErrRouteNotFound = errors.New("unknown route to service")
 )
 

--- a/http/integration_test.go
+++ b/http/integration_test.go
@@ -277,7 +277,7 @@ func (s *BackendPoolIntegrationTestSuite) buildBackends() {
 }
 
 func (s *BackendPoolIntegrationTestSuite) SimpleCtx() context.Context {
-	ctx, _ := context.WithTimeout(context.TODO(), 2*time.Second)
+	ctx, _ := context.WithTimeout(context.TODO(), 5*time.Second)
 	return ctx
 }
 

--- a/http/integration_test.go
+++ b/http/integration_test.go
@@ -1,34 +1,27 @@
 package http_integration
 
 import (
-	"net"
-
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
 	"path"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
-
-	"io/ioutil"
 
 	"github.com/mwitkow/go-conntrack/connhelpers"
 	"github.com/mwitkow/go-srvlb/srv"
 	pb_res "github.com/mwitkow/kedge/_protogen/kedge/config/common/resolvers"
 	pb_be "github.com/mwitkow/kedge/_protogen/kedge/config/http/backends"
 	pb_route "github.com/mwitkow/kedge/_protogen/kedge/config/http/routes"
-
-	"fmt"
-
-	"context"
-	"net/http"
-	"net/url"
-
-	"errors"
-
-	"strings"
-
 	"github.com/mwitkow/kedge/http/backendpool"
 	"github.com/mwitkow/kedge/http/director"
 	"github.com/mwitkow/kedge/http/director/router"

--- a/http/lbtransport/transport_test.go
+++ b/http/lbtransport/transport_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"io"
+
 	"github.com/mwitkow/go-srvlb/grpc"
 	"github.com/mwitkow/go-srvlb/srv"
 	"github.com/mwitkow/kedge/http/lbtransport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"io"
 )
 
 var (

--- a/lib/map/iface.go
+++ b/lib/map/iface.go
@@ -1,0 +1,21 @@
+package kedge_map
+
+import "net/url"
+
+type Mapper interface {
+	// Map maps a target's DNS name (e.g. myservice.prod.ext.europe-cluster.local) to a (public) URL of the Kedge
+	// fronting that destination. The returned Scheme is deciding whether the Kedge connection is secure.
+	Map(targetAuthorityDnsName string) (*url.URL, error)
+}
+
+func Single(kedgeUrl *url.URL) Mapper {
+	return &single{kedgeUrl}
+}
+
+type single struct {
+	kedgeUrl *url.URL
+}
+
+func (s *single) Map(targetAuthorityDnsName string) (*url.URL, error) {
+	return s.kedgeUrl, nil
+}

--- a/lib/resolvers/k8s.go
+++ b/lib/resolvers/k8s.go
@@ -1,12 +1,12 @@
 package resolvers
 
-
 import (
 	pb "github.com/mwitkow/kedge/_protogen/kedge/config/common/resolvers"
 
-	"google.golang.org/grpc/naming"
 	"fmt"
+
 	"github.com/sercand/kuberesolver"
+	"google.golang.org/grpc/naming"
 )
 
 func NewK8sFromConfig(conf *pb.KubeResolver) (target string, namer naming.Resolver, err error) {

--- a/lib/resolvers/srv.go
+++ b/lib/resolvers/srv.go
@@ -1,11 +1,12 @@
 package resolvers
 
 import (
-	pb "github.com/mwitkow/kedge/_protogen/kedge/config/common/resolvers"
-	"google.golang.org/grpc/naming"
+	"time"
+
 	"github.com/mwitkow/go-srvlb/grpc"
 	"github.com/mwitkow/go-srvlb/srv"
-	"time"
+	pb "github.com/mwitkow/kedge/_protogen/kedge/config/common/resolvers"
+	"google.golang.org/grpc/naming"
 )
 
 var (
@@ -15,5 +16,3 @@ var (
 func NewSrvFromConfig(conf *pb.SrvResolver) (target string, namer naming.Resolver, err error) {
 	return conf.GetDnsName(), grpcsrvlb.New(ParentSrvResolver), nil
 }
-
-

--- a/server/configs.go
+++ b/server/configs.go
@@ -7,9 +7,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/mwitkow/kedge/server/sharedflags"
 	"github.com/mwitkow/go-nicejsonpb"
 	pb_config "github.com/mwitkow/kedge/_protogen/kedge/config"
+	"github.com/mwitkow/kedge/server/sharedflags"
 
 	grpc_bp "github.com/mwitkow/kedge/grpc/backendpool"
 	grpc_router "github.com/mwitkow/kedge/grpc/director/router"

--- a/server/main.go
+++ b/server/main.go
@@ -37,7 +37,7 @@ var (
 
 	flagHttpMaxWriteTimeout = sharedflags.Set.Duration("server_http_max_write_timeout", 10*time.Second, "HTTP server config, max write duration.")
 	flagHttpMaxReadTimeout  = sharedflags.Set.Duration("server_http_max_read_timeout", 10*time.Second, "HTTP server config, max read duration.")
-	flagGrpcWithTracing = sharedflags.Set.Bool("server_tracing_grpc_enabled", true, "Whether enable gRPC tracing (could be expensive).")
+	flagGrpcWithTracing     = sharedflags.Set.Bool("server_tracing_grpc_enabled", true, "Whether enable gRPC tracing (could be expensive).")
 )
 
 func main() {

--- a/server/tls_flags.go
+++ b/server/tls_flags.go
@@ -28,7 +28,7 @@ var (
 
 	flagTlsServerClientCertRequired = sharedflags.Set.Bool(
 		"server_tls_client_cert_required",
-		false,
+		true,
 		"Controls whether a testclient certificate is required. Only used if server_tls_client_ca_files is not empty. If true, connections that don't have a testclient CA will be rejected.")
 )
 

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+echo "" > coverage.txt
+
+for d in $(go list ./... | grep -v vendor); do
+    echo -e "TESTS FOR: for \033[0;35m${d}\033[0m"
+    go test -race -v -coverprofile=profile.coverage.out -covermode=atomic $d
+    if [ -f profile.coverage.out ]; then
+        cat profile.coverage.out >> coverage.txt
+        rm profile.coverage.out
+    fi
+    echo ""
+done


### PR DESCRIPTION
This PR adds a `grpc.Dial`-equivalent that performs a dial over a Kedge server: `kedge_grpc. DialThroughKedge`.

Additionally, it adds a first slab of `kedge_mapper`, an interface that in the near future will map a route authority name external name (e.g. `myservice.kedgesvc.cluster-a.internal.example.com` to `https://gateway.cluster-a.example.com`)
