### PR TITLE
Moved to new lowercase logrus & go-srvlb package

### DIFF
--- a/grpc/integration_test.go
+++ b/grpc/integration_test.go
@@ -14,7 +14,7 @@ import (
 	"io/ioutil"
 
 	"github.com/mwitkow/go-conntrack/connhelpers"
-	"github.com/mwitkow/go-srvlb/srv"
+	"github.com/improbable-eng/go-srvlb/srv"
 	"github.com/mwitkow/grpc-proxy/proxy"
 	pb_res "github.com/mwitkow/kedge/_protogen/kedge/config/common/resolvers"
 	pb_be "github.com/mwitkow/kedge/_protogen/kedge/config/grpc/backends"

--- a/http/director/proxy.go
+++ b/http/director/proxy.go
@@ -1,14 +1,11 @@
 package director
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httputil"
-
-	"fmt"
-
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/mwitkow/go-conntrack"
 	"github.com/mwitkow/go-httpwares/tags"
 	"github.com/mwitkow/kedge/http/backendpool"
@@ -17,6 +14,7 @@ import (
 	"github.com/mwitkow/kedge/http/director/router"
 	"github.com/mwitkow/kedge/lib/sharedflags"
 	"github.com/oxtoacart/bpool"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/http/integration_test.go
+++ b/http/integration_test.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	"github.com/mwitkow/go-conntrack/connhelpers"
-	"github.com/mwitkow/go-srvlb/srv"
+	"github.com/improbable-eng/go-srvlb/srv"
 	pb_res "github.com/mwitkow/kedge/_protogen/kedge/config/common/resolvers"
 	pb_be "github.com/mwitkow/kedge/_protogen/kedge/config/http/backends"
 	pb_route "github.com/mwitkow/kedge/_protogen/kedge/config/http/routes"

--- a/http/lbtransport/transport_test.go
+++ b/http/lbtransport/transport_test.go
@@ -10,8 +10,8 @@ import (
 
 	"io"
 
-	"github.com/mwitkow/go-srvlb/grpc"
-	"github.com/mwitkow/go-srvlb/srv"
+	"github.com/improbable-eng/go-srvlb/grpc"
+	"github.com/improbable-eng/go-srvlb/srv"
 	"github.com/mwitkow/kedge/http/lbtransport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/lib/resolvers/srv.go
+++ b/lib/resolvers/srv.go
@@ -3,8 +3,8 @@ package resolvers
 import (
 	"time"
 
-	"github.com/mwitkow/go-srvlb/grpc"
-	"github.com/mwitkow/go-srvlb/srv"
+	"github.com/improbable-eng/go-srvlb/grpc"
+	"github.com/improbable-eng/go-srvlb/srv"
 	pb "github.com/mwitkow/kedge/_protogen/kedge/config/common/resolvers"
 	"google.golang.org/grpc/naming"
 )

--- a/server/README.md
+++ b/server/README.md
@@ -79,6 +79,7 @@ Driven through two config files:
 
 Here's an example that runs the server listening on four ports (80 for debug HTTP, 443 for HTTPS+gRPCTLS, 444 for gRPCTLS, 81 for gRPC plain text), and requiring 
 client side certs:
+
 ```sh
 go build 
 ./server \

--- a/server/configs.go
+++ b/server/configs.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/Sirupsen/logrus"
 	"github.com/golang/protobuf/proto"
 	"github.com/mwitkow/go-flagz/protobuf"
 	"github.com/mwitkow/go-proto-validators"
@@ -14,6 +13,7 @@ import (
 	http_adhoc "github.com/mwitkow/kedge/http/director/adhoc"
 	http_router "github.com/mwitkow/kedge/http/director/router"
 	"github.com/mwitkow/kedge/lib/sharedflags"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/server/main.go
+++ b/server/main.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
@@ -25,6 +24,7 @@ import (
 	"github.com/mwitkow/kedge/lib/sharedflags"
 	"github.com/pressly/chi"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 	_ "golang.org/x/net/trace" // so /debug/requst gets registered.
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/server/tls_flags.go
+++ b/server/tls_flags.go
@@ -1,14 +1,13 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
-
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
 
 	"github.com/mwitkow/go-conntrack/connhelpers"
 	"github.com/mwitkow/kedge/lib/sharedflags"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/test/grpctestclient/client.go
+++ b/test/grpctestclient/client.go
@@ -1,23 +1,18 @@
 package main
 
 import (
+	"crypto/tls"
+	"io"
+	"net/url"
+	"os"
 	"time"
 
-	"golang.org/x/net/context"
-
-	"github.com/Sirupsen/logrus"
 	google_protobuf "github.com/golang/protobuf/ptypes/empty"
 	pb_base "github.com/mwitkow/kedge/_protogen/base"
-
-	"io"
-	"os"
-
-	"crypto/tls"
-
-	"net/url"
-
 	"github.com/mwitkow/kedge/grpc/client"
 	"github.com/mwitkow/kedge/lib/map"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
 )
 
 var (


### PR DESCRIPTION
- to avoid 'case-insensitive import collision' and other errors.

Additionally: Reorder imports with impformat.

See: https://github.com/sirupsen/logrus/issues/543

This blocks further changes due to package imports that already imports new package (lowercase).
Also it is blocked by https://github.com/mwitkow/go-httpwares/pull/16

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>