### PR TITLE
Added trial dialing inside loadbalancer policy. We should be resilient on wrong DNS entries for SRV lookup.

### DIFF
--- a/http/backendpool/backend.go
+++ b/http/backendpool/backend.go
@@ -128,9 +128,9 @@ func chooseNamingResolver(cnf *pb.Backend) (string, naming.Resolver, error) {
 func chooseBalancerPolicy(cnf *pb.Backend) lbtransport.LBPolicy {
 	switch cnf.GetBalancer() {
 	case pb.Balancer_ROUND_ROBIN:
-		return lbtransport.RoundRobinPolicy()
+		return lbtransport.RoundRobinPolicyFromFlags()
 	default:
-		return lbtransport.RoundRobinPolicy()
+		return lbtransport.RoundRobinPolicyFromFlags()
 	}
 }
 

--- a/http/lbtransport/policy.go
+++ b/http/lbtransport/policy.go
@@ -1,8 +1,22 @@
 package lbtransport
 
 import (
+	"context"
+	"fmt"
+	"net"
 	"net/http"
+	"sync"
 	"sync/atomic"
+	"time"
+
+	"github.com/mwitkow/kedge/lib/sharedflags"
+)
+
+var (
+	flagBlacklistBackoff = sharedflags.Set.Duration("lbtransport_failed_target_backoff_duration", 2*time.Second,
+		"Duration to keep failed targets in blacklist. Set 0 to disable checking & blacklisting targets.")
+	flagTrialDialTimeout = sharedflags.Set.Duration("lbtransport_trial_dial_timeout", 500*time.Millisecond,
+		"Timeout for trial dialing if enabled.")
 )
 
 // LBPolicy decides which target to pick for a given call.
@@ -16,17 +30,107 @@ type Target struct {
 	DialAddr string
 }
 
-type simpleRoundRobinPolicy struct {
+// roundRobinPolicy picks target using round robin behaviour.
+// It also dials to the chosen target to check if it is accessible. That handles the situation when DNS
+// resolution contains invalid targets. If the target is not accessible, it blacklists it for defined period of time called
+// "blacklist backoff".
+type roundRobinPolicy struct {
+	blacklistBackoffDuration time.Duration
+	blacklistMu              sync.Mutex
+	blacklistedTargets       map[Target]time.Time
+
 	atomicCounter uint64
+
+	dialTimeout time.Duration
+	tryDialFunc func(ctx context.Context, target *Target) bool
+
+	timeNow func() time.Time
 }
 
-func RoundRobinPolicy() LBPolicy {
-	return &simpleRoundRobinPolicy{}
+func RoundRobinPolicyFromFlags() LBPolicy {
+	return RoundRobinPolicy(*flagBlacklistBackoff, *flagTrialDialTimeout)
 }
 
-func (rr *simpleRoundRobinPolicy) Pick(req *http.Request, currentTargets []*Target) (*Target, error) {
-	count := uint64(len(currentTargets))
-	id := atomic.AddUint64(&(rr.atomicCounter), 1)
-	targetId := int(id % count)
-	return currentTargets[targetId], nil
+func RoundRobinPolicy(backoffDuration time.Duration, dialTimeout time.Duration) LBPolicy {
+	rr := &roundRobinPolicy{
+		blacklistBackoffDuration: backoffDuration,
+		blacklistedTargets:       make(map[Target]time.Time),
+		dialTimeout:              dialTimeout,
+
+		tryDialFunc: tryDial,
+		timeNow:     time.Now,
+	}
+	return rr
+}
+
+func (rr *roundRobinPolicy) isTargetBlacklisted(target *Target) bool {
+	rr.blacklistMu.Lock()
+	defer rr.blacklistMu.Unlock()
+
+	failTime, ok := rr.blacklistedTargets[*target]
+	if !ok {
+		return false
+	}
+
+	// It is blacklisted, but check if still valid.
+	if failTime.Add(rr.blacklistBackoffDuration).Before(rr.timeNow()) {
+		// Expired.
+		delete(rr.blacklistedTargets, *target)
+		return false
+	}
+
+	return true
+}
+
+func (rr *roundRobinPolicy) blacklistTarget(target *Target) {
+	rr.blacklistMu.Lock()
+	defer rr.blacklistMu.Unlock()
+
+	rr.blacklistedTargets[*target] = rr.timeNow()
+}
+
+func (rr *roundRobinPolicy) isTrialDialingDisabled() bool {
+	return rr.blacklistBackoffDuration == (0 * time.Microsecond)
+}
+
+func (rr *roundRobinPolicy) Pick(r *http.Request, currentTargets []*Target) (*Target, error) {
+	for range currentTargets {
+		count := uint64(len(currentTargets))
+		id := atomic.AddUint64(&(rr.atomicCounter), 1)
+		targetId := int(id % count)
+		target := currentTargets[targetId]
+
+		if rr.isTrialDialingDisabled() {
+			return currentTargets[targetId], nil
+		}
+
+		if rr.isTargetBlacklisted(target) {
+			// That target is blacklisted. Check another one.
+			continue
+		}
+
+		// Target not blacklisted before, try it first.
+		dialCtx, cancel := context.WithTimeout(r.Context(), rr.dialTimeout)
+		if rr.tryDialFunc(dialCtx, target) {
+			cancel()
+			return currentTargets[targetId], nil
+		}
+		cancel()
+		rr.blacklistTarget(target)
+	}
+	return nil, fmt.Errorf("All targets %d are failing, try later.", len(currentTargets))
+}
+
+func tryDial(ctx context.Context, target *Target) bool {
+	var dialTimeout time.Duration
+	if deadline, ok := ctx.Deadline(); ok {
+		dialTimeout = deadline.Sub(time.Now())
+	}
+	// Try to do quick dial to check if the target is listening.
+	conn, err := net.DialTimeout("tcp", target.DialAddr, dialTimeout)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
 }

--- a/http/lbtransport/policy_test.go
+++ b/http/lbtransport/policy_test.go
@@ -1,0 +1,137 @@
+package lbtransport
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testFailBlacklistDuration = 2 * time.Second
+	testOKDial                = func(_ context.Context, _ *Target) bool { return true }
+)
+
+func TestRoundRobinPolicy_PickWithBlacklist(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://127.0.0.1/x", nil)
+
+	now := time.Now()
+	rr := &roundRobinPolicy{
+		blacklistBackoffDuration: testFailBlacklistDuration,
+		blacklistedTargets:       make(map[Target]time.Time),
+		tryDialFunc:              testOKDial,
+		timeNow: func() time.Time {
+			return now
+		},
+	}
+
+	testTargets := []*Target{
+		{
+			DialAddr: "0",
+		},
+		{
+			DialAddr: "1",
+		},
+		{
+			DialAddr: "2",
+		},
+	}
+
+	// Picking serially should give targets in exact order.
+	target, err := rr.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[1], target)
+
+	target, err = rr.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[2], target)
+
+	target, err = rr.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[0], target)
+
+	target, err = rr.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[1], target)
+
+	rr.atomicCounter = 0
+	rr.tryDialFunc = func(_ context.Context, target *Target) bool {
+		if target == testTargets[0] {
+			return false
+		}
+		return true
+	}
+
+	// With target nr 0 failing on dial, we should blacklist it and picking serially should give targets in exact order without that failing.
+	target, err = rr.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[1], target)
+
+	target, err = rr.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[2], target)
+
+	target, err = rr.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[1], target)
+
+	assert.True(t, rr.isTargetBlacklisted(testTargets[0]))
+
+	rr.atomicCounter = 0
+	rr.tryDialFunc = func(_ context.Context, target *Target) bool {
+		if target == testTargets[1] {
+			return false
+		}
+		return true
+	}
+
+	// With target nr 1 failing on dial, we should blacklist it and picking serially should give us the last working target.
+	// Time not passed so even that we can dial to target nr 0 it should stay in blacklist.
+	target, err = rr.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[2], target)
+
+	target, err = rr.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[2], target)
+
+	assert.True(t, rr.isTargetBlacklisted(testTargets[0]))
+	assert.True(t, rr.isTargetBlacklisted(testTargets[1]))
+
+	rr.tryDialFunc = func(_ context.Context, target *Target) bool {
+		if target == testTargets[2] {
+			return false
+		}
+		return true
+	}
+
+	_, err = rr.Pick(req, testTargets)
+	require.Error(t, err, "all targets should be in blacklist")
+
+	assert.True(t, rr.isTargetBlacklisted(testTargets[0]))
+	assert.True(t, rr.isTargetBlacklisted(testTargets[1]))
+	assert.True(t, rr.isTargetBlacklisted(testTargets[2]))
+
+	rr.atomicCounter = 0
+	// Let's imagine time passed, so all blacklisted guys should be fine now.
+	rr.timeNow = func() time.Time {
+		return now.Add(testFailBlacklistDuration).Add(10 * time.Millisecond)
+
+	}
+
+	// Still target nr 2 is failing on dial, but rest should be removed from blacklist and included in pick.
+	target, err = rr.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[1], target)
+
+	target, err = rr.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[0], target)
+
+	target, err = rr.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[1], target)
+}

--- a/http/lbtransport/transport.go
+++ b/http/lbtransport/transport.go
@@ -100,10 +100,12 @@ func (s *tripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	if len(targetRef) == 0 {
 		return nil, fmt.Errorf("lb: no targets available, last resolve err: %v", lastResolvErr)
 	}
+
 	target, err := s.policy.Pick(r, targetRef)
 	if err != nil {
 		return nil, fmt.Errorf("lb: failed choosing target: %v", err)
 	}
+
 	// Override the host for downstream Tripper, usually http.DefaultTransport.
 	// http.Default transport uses `URL.Host` for Dial(<host>) and relevant connection pooling.
 	// We override it to make sure it enters the appropriate dial method and hte appropriate connection pool.


### PR DESCRIPTION
Also:
- Added unit tests & integration test with new round robin.
- Fixed possible races inside transport integration tests.

Without this fix we always fail on some calls due to obsolete DNS entries inside our k8s cluster.

NOTE: We should also consider retry logic somewhere here (or in another tripperware)

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>