### PR TITLE
Moved lb policy to not do trial Dials, but instead watch on dial errors from default round trip.

### DIFF
--- a/http/integration_test.go
+++ b/http/integration_test.go
@@ -143,6 +143,7 @@ func unknownPingbackHandler(serverAddr string) http.Handler {
 		resp.Header().Set("x-test-auth-value", req.Header.Get("Authorization"))
 		resp.Header().Set("x-test-proxy-auth-value", req.Header.Get("Proxy-Authorization"))
 		resp.WriteHeader(http.StatusAccepted) // accepted to make sure stuff is slightly different.
+		resp.Write([]byte("TEST"))
 	})
 }
 
@@ -368,6 +369,12 @@ func (s *HttpProxyingIntegrationSuite) assertSuccessfulPingback(req *http.Reques
 	assert.Equal(s.T(), req.URL.Host, resp.Header.Get("x-test-req-host"), "host seen on backend must match requested host")
 	assert.Equal(s.T(), authValue, resp.Header.Get("x-test-auth-value"))
 	assert.Empty(s.T(), resp.Header.Get("x-test-proxy-auth-value")) // Proxy value should be cut down.
+
+	s.Require().NotNil(resp.Body, "Body should not be empty")
+	b, err := ioutil.ReadAll(resp.Body)
+	s.Require().NoError(err, "no error on a read all body")
+	defer resp.Body.Close()
+	s.Assert().Equal("TEST", string(b))
 }
 
 func testRequest(url string, backendSecret string, proxySecret string) *http.Request {

--- a/http/lbtransport/policy.go
+++ b/http/lbtransport/policy.go
@@ -1,9 +1,7 @@
 package lbtransport
 
 import (
-	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -19,10 +17,17 @@ var (
 		"Timeout for trial dialing if enabled.")
 )
 
-// LBPolicy decides which target to pick for a given call.
 type LBPolicy interface {
+	// Picker returns PolicyPicker that is suitable to be used within single request.
+	Picker() LBPolicyPicker
+}
+
+// LBPolicyPicker decides which target to pick for a given call. Should be short-living.
+type LBPolicyPicker interface {
 	// Pick decides on which target to use for the request out of the provided ones.
 	Pick(req *http.Request, currentTargets []*Target) (*Target, error)
+	// ExcludeHost excludes the given target for a short time. It is useful to report no connection (even temporary).
+	ExcludeTarget(*Target)
 }
 
 // Target represents the canonical address of a backend.
@@ -31,9 +36,9 @@ type Target struct {
 }
 
 // roundRobinPolicy picks target using round robin behaviour.
-// It also dials to the chosen target to check if it is accessible. That handles the situation when DNS
-// resolution contains invalid targets. If the target is not accessible, it blacklists it for defined period of time called
-// "blacklist backoff".
+// It does NOT dial to the chosen target to check if it is accessible, instead it exposes ExcludeTarget method that allows to report
+// connection troubles. That handles the situation when DNS resolution contains invalid targets. In  that case, it
+// blacklists it for defined period of time called "blacklist backoff".
 type roundRobinPolicy struct {
 	blacklistBackoffDuration time.Duration
 	blacklistMu              sync.Mutex
@@ -42,9 +47,7 @@ type roundRobinPolicy struct {
 	atomicCounter uint64
 
 	dialTimeout time.Duration
-	tryDialFunc func(ctx context.Context, target *Target) bool
-
-	timeNow func() time.Time
+	timeNow     func() time.Time
 }
 
 func RoundRobinPolicyFromFlags() LBPolicy {
@@ -57,8 +60,7 @@ func RoundRobinPolicy(backoffDuration time.Duration, dialTimeout time.Duration) 
 		blacklistedTargets:       make(map[Target]time.Time),
 		dialTimeout:              dialTimeout,
 
-		tryDialFunc: tryDial,
-		timeNow:     time.Now,
+		timeNow: time.Now,
 	}
 
 	go func() {
@@ -108,48 +110,52 @@ func (rr *roundRobinPolicy) blacklistTarget(target *Target) {
 	rr.blacklistedTargets[*target] = rr.timeNow()
 }
 
-func (rr *roundRobinPolicy) isTrialDialingDisabled() bool {
+func (rr *roundRobinPolicy) isBlacklistDisabled() bool {
 	return rr.blacklistBackoffDuration == (0 * time.Microsecond)
 }
 
-func (rr *roundRobinPolicy) Pick(r *http.Request, currentTargets []*Target) (*Target, error) {
+func (rr *roundRobinPolicy) Picker() LBPolicyPicker {
+	return &roundRobinPolicyPicker{
+		base:           rr,
+		localBlacklist: make(map[Target]struct{}),
+	}
+}
+
+type roundRobinPolicyPicker struct {
+	base *roundRobinPolicy
+
+	// To make sure we only retry for valid targets.
+	localBlacklist map[Target]struct{}
+}
+
+func (rr *roundRobinPolicyPicker) isTargetLocallyBlacklisted(target *Target) bool {
+	_, ok := rr.localBlacklist[*target]
+	return ok
+}
+
+func (rr *roundRobinPolicyPicker) Pick(r *http.Request, currentTargets []*Target) (*Target, error) {
 	for range currentTargets {
 		count := uint64(len(currentTargets))
-		id := atomic.AddUint64(&(rr.atomicCounter), 1)
+		id := atomic.AddUint64(&(rr.base.atomicCounter), 1)
 		targetId := int(id % count)
 		target := currentTargets[targetId]
 
-		if rr.isTrialDialingDisabled() {
-			return currentTargets[targetId], nil
+		if rr.isTargetLocallyBlacklisted(target) {
+			// That target is blacklisted in local blacklist. Check another target.
+			continue
 		}
 
-		if rr.isTargetBlacklisted(target) {
+		if !rr.base.isBlacklistDisabled() && rr.base.isTargetBlacklisted(target) {
 			// That target is blacklisted. Check another one.
 			continue
 		}
 
-		// Target not blacklisted before, try it first.
-		dialCtx, cancel := context.WithTimeout(r.Context(), rr.dialTimeout)
-		if rr.tryDialFunc(dialCtx, target) {
-			cancel()
-			return currentTargets[targetId], nil
-		}
-		cancel()
-		rr.blacklistTarget(target)
+		return currentTargets[targetId], nil
 	}
 	return nil, fmt.Errorf("All targets %d are failing, try later.", len(currentTargets))
 }
 
-func tryDial(ctx context.Context, target *Target) bool {
-	var dialTimeout time.Duration
-	if deadline, ok := ctx.Deadline(); ok {
-		dialTimeout = deadline.Sub(time.Now())
-	}
-	// Try to do quick dial to check if the target is listening.
-	_, err := net.DialTimeout("tcp", target.DialAddr, dialTimeout)
-	if err != nil {
-		return false
-	}
-	// Don't close connection by purpose. It will be reused anyway by this request.
-	return true
+func (rr *roundRobinPolicyPicker) ExcludeTarget(target *Target) {
+	rr.base.blacklistTarget(target)
+	rr.localBlacklist[*target] = struct{}{}
 }

--- a/http/lbtransport/policy_test.go
+++ b/http/lbtransport/policy_test.go
@@ -1,7 +1,6 @@
 package lbtransport
 
 import (
-	"context"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -12,17 +11,15 @@ import (
 
 var (
 	testFailBlacklistDuration = 2 * time.Second
-	testOKDial                = func(_ context.Context, _ *Target) bool { return true }
 )
 
-func TestRoundRobinPolicy_PickWithBlacklist(t *testing.T) {
+func TestRoundRobinPolicy_PickWithGlobalBlacklists(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://127.0.0.1/x", nil)
 
 	now := time.Now()
 	rr := &roundRobinPolicy{
 		blacklistBackoffDuration: testFailBlacklistDuration,
 		blacklistedTargets:       make(map[Target]time.Time),
-		tryDialFunc:              testOKDial,
 		timeNow: func() time.Time {
 			return now
 		},
@@ -40,75 +37,70 @@ func TestRoundRobinPolicy_PickWithBlacklist(t *testing.T) {
 		},
 	}
 
+	// Test Global blacklist.
+	picker := rr.Picker()
 	// Picking serially should give targets in exact order.
-	target, err := rr.Pick(req, testTargets)
+	target, err := picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, testTargets[1], target)
 
-	target, err = rr.Pick(req, testTargets)
+	target, err = picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, testTargets[2], target)
 
-	target, err = rr.Pick(req, testTargets)
+	target, err = picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, testTargets[0], target)
 
-	target, err = rr.Pick(req, testTargets)
+	target, err = picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, testTargets[1], target)
 
 	rr.atomicCounter = 0
-	rr.tryDialFunc = func(_ context.Context, target *Target) bool {
-		if target == testTargets[0] {
-			return false
-		}
-		return true
-	}
+	picker.ExcludeTarget(testTargets[0])
 
-	// With target nr 0 failing on dial, we should blacklist it and picking serially should give targets in exact order without that failing.
-	target, err = rr.Pick(req, testTargets)
+	// To test global blacklist we need to spawn another picker!
+	picker = rr.Picker()
+
+	// With target nr 0 in Global blacklist, even new picker should give targets in exact order without that failing without the first one.
+	target, err = picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, testTargets[1], target)
 
-	target, err = rr.Pick(req, testTargets)
+	target, err = picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, testTargets[2], target)
 
-	target, err = rr.Pick(req, testTargets)
+	target, err = picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, testTargets[1], target)
 
 	assert.True(t, rr.isTargetBlacklisted(testTargets[0]))
 
 	rr.atomicCounter = 0
-	rr.tryDialFunc = func(_ context.Context, target *Target) bool {
-		if target == testTargets[1] {
-			return false
-		}
-		return true
-	}
+	picker.ExcludeTarget(testTargets[1])
 
-	// With target nr 1 failing on dial, we should blacklist it and picking serially should give us the last working target.
+	// To test global blacklist we need to spawn another picker!
+	picker = rr.Picker()
+
+	// With target nr 1 excluded, picking serially should give us the last working target.
 	// Time not passed so even that we can dial to target nr 0 it should stay in blacklist.
-	target, err = rr.Pick(req, testTargets)
+	target, err = picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, testTargets[2], target)
 
-	target, err = rr.Pick(req, testTargets)
+	target, err = picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, testTargets[2], target)
 
 	assert.True(t, rr.isTargetBlacklisted(testTargets[0]))
 	assert.True(t, rr.isTargetBlacklisted(testTargets[1]))
 
-	rr.tryDialFunc = func(_ context.Context, target *Target) bool {
-		if target == testTargets[2] {
-			return false
-		}
-		return true
-	}
+	picker.ExcludeTarget(testTargets[2])
+	// To test global blacklist we need to spawn another picker!
+	picker = rr.Picker()
 
-	_, err = rr.Pick(req, testTargets)
+	_, err = picker.Pick(req, testTargets)
 	require.Error(t, err, "all targets should be in blacklist")
 
 	assert.True(t, rr.isTargetBlacklisted(testTargets[0]))
@@ -119,35 +111,32 @@ func TestRoundRobinPolicy_PickWithBlacklist(t *testing.T) {
 	// Let's imagine time passed, so all blacklisted guys should be fine now.
 	rr.timeNow = func() time.Time {
 		return now.Add(testFailBlacklistDuration).Add(10 * time.Millisecond)
-
 	}
+	picker.ExcludeTarget(testTargets[2])
 
-	// Still target nr 2 is failing on dial, but rest should be removed from blacklist and included in pick.
-	target, err = rr.Pick(req, testTargets)
+	// To test global blacklist we need to spawn another picker!
+	picker = rr.Picker()
+
+	// Still target nr 2 is excluded, but rest should be removed from blacklist and included in pick.
+	target, err = picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, testTargets[1], target)
 
-	target, err = rr.Pick(req, testTargets)
+	target, err = picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, testTargets[0], target)
 
-	target, err = rr.Pick(req, testTargets)
+	target, err = picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, testTargets[1], target)
 }
 
-func TestRoundRobinPolicy_CleanupBlacklist(t *testing.T) {
+func TestRoundRobinPolicy_PickWithLocalBlacklists(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://127.0.0.1/x", nil)
 	rr := &roundRobinPolicy{
-		blacklistBackoffDuration: testFailBlacklistDuration,
+		blacklistBackoffDuration: 0 * time.Millisecond, // No global blacklist!
 		blacklistedTargets:       make(map[Target]time.Time),
-		tryDialFunc:              testOKDial,
-	}
-
-	now := time.Now()
-	rr.timeNow = func() time.Time {
-
-		return now
+		timeNow: time.Now,
 	}
 
 	testTargets := []*Target{
@@ -161,14 +150,96 @@ func TestRoundRobinPolicy_CleanupBlacklist(t *testing.T) {
 			DialAddr: "2",
 		},
 	}
-	assert.Equal(t, 0, len(rr.blacklistedTargets), "at the beginning blacklist should be empty.")
-	rr.tryDialFunc = func(_ context.Context, target *Target) bool {
-		if target == testTargets[1] {
-			return false
-		}
-		return true
+
+	picker := rr.Picker()
+
+	// Picking serially should give targets in exact order.
+	target, err := picker.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[1], target)
+
+	target, err = picker.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[2], target)
+
+	target, err = picker.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[0], target)
+
+	target, err = picker.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[1], target)
+
+	rr.atomicCounter = 0
+	picker.ExcludeTarget(testTargets[0])
+
+	// With target nr 0 only in local blacklist, even new picker should give targets in exact order without that failing without the first one.
+	target, err = picker.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[1], target)
+
+	target, err = picker.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[2], target)
+
+	target, err = picker.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[1], target)
+
+	assert.True(t, picker.(*roundRobinPolicyPicker).isTargetLocallyBlacklisted(testTargets[0]))
+
+	rr.atomicCounter = 0
+	picker.ExcludeTarget(testTargets[1])
+
+	// With target nr 1 excluded, picking serially should give us the last working target.
+	target, err = picker.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[2], target)
+
+	target, err = picker.Pick(req, testTargets)
+	require.NoError(t, err)
+	assert.Equal(t, testTargets[2], target)
+
+	assert.True(t, picker.(*roundRobinPolicyPicker).isTargetLocallyBlacklisted(testTargets[0]))
+	assert.True(t, picker.(*roundRobinPolicyPicker).isTargetLocallyBlacklisted(testTargets[1]))
+
+	picker.ExcludeTarget(testTargets[2])
+
+	_, err = picker.Pick(req, testTargets)
+	require.Error(t, err, "all targets should be in blacklist")
+
+	assert.True(t, picker.(*roundRobinPolicyPicker).isTargetLocallyBlacklisted(testTargets[0]))
+	assert.True(t, picker.(*roundRobinPolicyPicker).isTargetLocallyBlacklisted(testTargets[1]))
+	assert.True(t, picker.(*roundRobinPolicyPicker).isTargetLocallyBlacklisted(testTargets[2]))
+}
+
+func TestRoundRobinPolicy_CleanupBlacklist(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://127.0.0.1/x", nil)
+	rr := &roundRobinPolicy{
+		blacklistBackoffDuration: testFailBlacklistDuration,
+		blacklistedTargets:       make(map[Target]time.Time),
 	}
-	_, err := rr.Pick(req, testTargets)
+
+	now := time.Now()
+	rr.timeNow = func() time.Time {
+		return now
+	}
+
+	picker := rr.Picker()
+	testTargets := []*Target{
+		{
+			DialAddr: "0",
+		},
+		{
+			DialAddr: "1",
+		},
+		{
+			DialAddr: "2",
+		},
+	}
+	assert.Equal(t, 0, len(rr.blacklistedTargets), "at the beginning blacklist should be empty.")
+	picker.ExcludeTarget(testTargets[1])
+	_, err := picker.Pick(req, testTargets)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(rr.blacklistedTargets), "after one fail blacklist should include one target")
 	rr.cleanUpBlacklist()

--- a/http/lbtransport/transport.go
+++ b/http/lbtransport/transport.go
@@ -1,10 +1,12 @@
 package lbtransport
 
 import (
-	"fmt"
+	"net"
 	"net/http"
 	"sync"
 
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc/naming"
 )
 
@@ -19,6 +21,22 @@ type tripper struct {
 	currentTargets []*Target
 	close          chan struct{}
 	mu             sync.RWMutex
+}
+
+var (
+	failedDialsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "kedge",
+			Subsystem: "http_lbtransport",
+			Name:      "failed_dials",
+			Help:      "Total number of failed dials that are in resolver and should blacklist the target.",
+		},
+		[]string{"resolve_addr", "target"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(failedDialsCounter)
 }
 
 // New creates a new load-balanced Round Tripper for a single backend.
@@ -86,22 +104,47 @@ func (s *tripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	//	return nil, fmt.Errorf("lb: request Host '%v' doesn't match Target destination '%v'", r.Host, s.targetName)
 	//}
 	s.mu.RLock()
-	targetRef := s.currentTargets
+	targetsRef := s.currentTargets
 	lastResolvErr := s.lastResolveError
 	s.mu.RUnlock()
-	if len(targetRef) == 0 {
-		return nil, fmt.Errorf("lb: no targets available, last resolve err: %v", lastResolvErr)
+	if len(targetsRef) == 0 {
+		return nil, errors.Wrap(lastResolvErr, "lb: no targets available")
 	}
 
-	target, err := s.policy.Pick(r, targetRef)
-	if err != nil {
-		return nil, fmt.Errorf("lb: failed choosing target: %v", err)
-	}
+	picker := s.policy.Picker()
+	for {
+		target, err := picker.Pick(r, targetsRef)
+		if err != nil {
+			return nil, errors.Wrap(err, "lb: failed choosing target")
+		}
 
-	// Override the host for downstream Tripper, usually http.DefaultTransport.
-	// http.Default transport uses `URL.Host` for Dial(<host>) and relevant connection pooling.
-	// We override it to make sure it enters the appropriate dial method and hte appropriate connection pool.
-	// See http.connectMethodKey.
-	r.URL.Host = target.DialAddr
-	return s.parent.RoundTrip(r)
+		// Override the host for downstream Tripper, usually http.DefaultTransport.
+		// http.Default transport uses `URL.Host` for Dial(<host>) and relevant connection pooling.
+		// We override it to make sure it enters the appropriate dial method and the appropriate connection pool.
+		// See http.connectMethodKey.
+		r.URL.Host = target.DialAddr
+		resp, err := s.parent.RoundTrip(r)
+		if err == nil {
+			return resp, nil
+		}
+
+		if !isDialError(err) {
+			return resp, err
+		}
+
+		failedDialsCounter.WithLabelValues(s.targetName, target.DialAddr).Inc()
+
+		// Retry without this target.
+		// NOTE: We need to trust picker that it blacklist the targets well.
+		picker.ExcludeTarget(target)
+	}
+}
+
+func isDialError(err error) bool {
+	if opErr, ok := err.(*net.OpError); ok {
+		if opErr.Op == "dial" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Reason: It was braking TLS handshake and causing misleading error message on server side.

PTAL @kdima
Signed-off-by: Bartek Plotka <bwplotka@gmail.com>